### PR TITLE
Adding support for special files in opam.ml

### DIFF
--- a/src/digodoc_lib/opam.ml
+++ b/src/digodoc_lib/opam.ml
@@ -61,6 +61,7 @@ let parse_changes filename =
       | 'D' -> Directory
       | 'F' -> File
       | 'L' -> Link
+      | 'S' -> Special
       | _ ->
           Printf.eprintf "[ %c ]%!" c;
           assert false

--- a/src/digodoc_lib/types.ml
+++ b/src/digodoc_lib/types.ml
@@ -15,6 +15,7 @@ type file_kind =
   | Directory
   | File
   | Link
+  | Special
 
 (* As returned by Objinfo.read : string -> unit list *)
 type comp_unit = {


### PR DESCRIPTION
Doesn't change behavior as this info is used nowhere, avoids a bad assertion when a special file is present.