### PR TITLE
Minor changes for mld handling, link differenciation and switch selection

### DIFF
--- a/html/_odoc-theme/odoc.css
+++ b/html/_odoc-theme/odoc.css
@@ -133,6 +133,9 @@ a.anchor
   text-align: right;
  }
 
+a.digodoc-opam { color: green; }
+a.digodoc-lib { color: purple; }
+
 *:target /* Linked highlight */
 { background-color: var(--color-bg-highlight);
   box-shadow: 0 0 0 3px var(--color-bg-highlight) }

--- a/src/digodoc_lib/odoc.ml
+++ b/src/digodoc_lib/odoc.ml
@@ -261,7 +261,7 @@ let generate_library_index state bb =
 
       let line =
       Printf.sprintf
-        {|<li><a href="%s/index.html"><code>%s</code></a> in opam <a href="%s/index.html">%s.%s</a></li>|}
+        {|<li><a href="%s/index.html"" class="digodoc-lib"><code>%s</code></a> in opam <a href="%s/index.html" class="digodoc-opam">%s.%s</a></li>|}
         pkg lib.lib_name
         opam_pkg
         lib.lib_opam.opam_name
@@ -279,7 +279,7 @@ let generate_library_index state bb =
 
       Printf.bprintf b "{1:info Library info}\n";
       Printf.bprintf b {|{%%html:<table class="package info">|};
-      Printf.bprintf b {|<tr><td>Opam package:</td><td><a href="../%s/index.html">%s.%s</a></td></tr>|}
+      Printf.bprintf b {|<tr><td>Opam package:</td><td><a href="../%s/index.html" class="digodoc-opam">%s.%s</a></td></tr>|}
         opam_pkg lib.lib_opam.opam_name lib.lib_opam.opam_version;
       Printf.bprintf b {|<tr><td>Directory:</td><td>%s</td></tr>|}
         lib.lib_dir.dir_name;
@@ -348,7 +348,7 @@ let generate_opam_index state bb =
 
       let line =
         Printf.sprintf
-        {|<li><a href="%s/index.html"><code>%s.%s</code></a> %s</li>|}
+        {|<li><a href="%s/index.html" class="digodoc-opam"><code>%s.%s</code></a> %s</li>|}
         pkg opam.opam_name
         opam.opam_version
         (match opam.opam_synopsis with
@@ -487,7 +487,7 @@ let generate_module_index state bb =
 
       let line =
       Printf.sprintf
-        {|<li><a href="%s/%s/index.html"><code>%s</code></a>%s in opam <a href="%s/index.html">%s.%s</a>%s</li>|}
+        {|<li><a href="%s/%s/index.html"><code>%s</code></a>%s in opam <a href="%s/index.html" class="digodoc-opam">%s.%s</a>%s</li>|}
         pkg
         mdl.mdl_name
         short_name
@@ -506,7 +506,7 @@ let generate_module_index state bb =
              ( String.concat ", "
                  ( StringMap.to_list mdl.mdl_libs |>
                    List.map (fun (_,lib) ->
-                       Printf.sprintf {|<a href="%s/index.html">%s</a>|}
+                       Printf.sprintf {|<a href="%s/index.html" class="digodoc-lib">%s</a>|}
                          (pkg_of_lib lib) lib.lib_name
                      ) ))
         )
@@ -528,7 +528,7 @@ let generate_meta_index state bb =
       let opam_pkg = pkg_of_opam opam in
       let line =
         Printf.sprintf
-          {|<li><a href="%s/index.html"><code>%s</code></a> in opam <a href="%s/index.html">%s.%s</a></li>|}
+          {|<li><a href="%s/index.html"><code>%s</code></a> in opam <a href="%s/index.html" class="digodoc-opam">%s.%s</a></li>|}
           pkg meta.meta_name
           opam_pkg
           opam.opam_name
@@ -541,7 +541,7 @@ let generate_meta_index state bb =
       Printf.bprintf b "{0:opam-%s Dune/OCamlfind Package %s\n"
         meta.meta_name meta.meta_name;
       Printf.bprintf b
-        {|{%%html:<nav><a href="../%s/index.html">%s.%s</a></nav>%%}|}
+        {|{%%html:<nav><a href="../%s/index.html" class="digodoc-opam">%s.%s</a></nav>%%}|}
         opam_pkg opam.opam_name opam.opam_version;
       Printf.bprintf b "}\n";
 

--- a/src/digodoc_lib/odoc.ml
+++ b/src/digodoc_lib/odoc.ml
@@ -421,6 +421,20 @@ let generate_opam_index state bb =
 *)
       Printf.bprintf b "</table>%%}\n";
 
+      let mldfiles = List.filter_map (function
+          | README_md _ | CHANGES_md _ | LICENSE_md _ -> None
+          | ODOC_PAGE mld -> Some mld
+        ) opam.opam_docs in
+      if mldfiles <> []
+      then begin
+        Printf.bprintf b "{1:pages Package documentation pages}\n";
+        Printf.bprintf b "{!pages:\n";
+        List.iter (fun mld ->
+            Printf.bprintf b "  %s\n" mld;
+          ) mldfiles;
+        Printf.bprintf b "}\n";
+        (* TODO, generate the doc and put in a link *)
+      end;
 
       Printf.bprintf b "{1:modules Package modules}\n";
       Printf.bprintf b "{!modules:\n";


### PR DESCRIPTION
* Mld handling: Still have to execute the mld compilation (they go with the opam file but I have to connect the finding of pkgs, will come soon)
* link differenciation: just adding some color on link to opam and library pages to make it easier to see what you're clicking on
* switch selection: manually overriding the OPAM_SWITCH_PREFIX for easier use without calling opam (I compile and execute in different switches)
