### PR TITLE
Fix in meta-file path. Source generation and linking with documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ _build
 /_opam
 /_build
 /_digodoc
+res.txt

--- a/src/digodoc_lib/compute.ml
+++ b/src/digodoc_lib/compute.ml
@@ -50,9 +50,12 @@ let check_file state ~objinfo opam_package file =
   let dirname = Filename.dirname file in
   let basename = Filename.basename file in
   let dir = Directory.get state dirname in
-  if basename = "META" then
-    let filename = state.opam_switch_prefix // file in
-    let meta_name = Meta_file.Parser.name_of_META file in
+  if basename = "META" || dirname = "metas" then
+    let filename, meta_name = 
+      if dirname = "metas" 
+      then Sys.getcwd() // file, opam_package.opam_name
+      else state.opam_switch_prefix // file, Meta_file.Parser.name_of_META file 
+    in
     (*    Printf.eprintf "opam package %S DEFINES ocamlfind package %S\n%!"
           opam_package.opam_name meta_name ; *)
 

--- a/src/digodoc_lib/globals.ml
+++ b/src/digodoc_lib/globals.ml
@@ -10,3 +10,5 @@
 (**************************************************************************)
 
 let digodoc_dir = "_digodoc"
+
+let htmlize_sources_dir = "_digodoc/sources"

--- a/src/digodoc_lib/main.ml
+++ b/src/digodoc_lib/main.ml
@@ -79,10 +79,14 @@ let main () =
   let cached = ref false in
   let switch = ref None in
   let continue_on_error = ref false in
+  let sources = ref true in 
   EZCMD.parse EZCMD.TYPES.[
 
       "--no-objinfo", Arg.Clear objinfo,
       " do not call ocamlobjinfo to attach modules to libraries";
+
+      "--no-sources", Arg.Clear sources,
+      "do not generate sources for opam packages";
 
       "--cached", Arg.Set cached,
       " read cached state";
@@ -124,6 +128,7 @@ let main () =
   let cached = !cached in
   let switch = !switch in
   let continue_on_error = !continue_on_error in
+  let sources = !sources in
   let state =
     if cached then
       let ic = open_in_bin cache_file  in
@@ -139,7 +144,7 @@ let main () =
         Printer.print state
     | GenerateHtml ->
         let state = get_state ~state ~objinfo ~switch in
-        Odoc.generate ~state ~continue_on_error;
+        Odoc.generate ~state ~continue_on_error ~sources;
         Index.generate ();
         (* Html.iter_html ~add_trailer:true Html.digodoc_html_dir *)
     | CheckLinks ->
@@ -183,7 +188,7 @@ let main () =
               exit 0
         end
     | HtmlizeSources dir ->
-        Htmlize.Main.htmlize "_digodoc/sources" [dir]
+        Htmlize.Main.htmlize Globals.htmlize_sources_dir [dir]
   end;
 
   List.iteri  (fun i args ->

--- a/src/digodoc_lib/odoc.ml
+++ b/src/digodoc_lib/odoc.ml
@@ -30,6 +30,28 @@ open Types
 
 let digodoc_odoc_dir = Globals.digodoc_dir // "odoc"
 
+let sources_dir = "sources"
+
+let fullname opam = opam.opam_name ^ "." ^ opam.opam_version
+
+let get_opam_sources ~continue_on_error opam =
+  let package_name = fullname opam in
+  let cmd = [
+    "opam"; "source";
+    "--dir"; sources_dir // package_name;
+    package_name]
+  in
+    try
+      Process.call ~continue_on_error (Array.of_list cmd)
+    with exn ->
+      Printf.eprintf "opam_error: %s\n%!" (Printexc.to_string exn)
+
+let sources_of_opam opam =
+  sources_dir // (fullname opam)
+
+let htmlize_sources_of_opam opam =
+  Globals.htmlize_sources_dir // fullname opam
+
 let pkg_of_opam opam =
   Printf.sprintf "OPAM.%s.%s"
     opam.opam_name opam.opam_version
@@ -622,7 +644,7 @@ let generate_library_pages state =
 
   ()
 
-let generate_opam_pages state =
+let generate_opam_pages ~sources state =
 
   StringMap.iter (fun _ opam ->
       let pkg = pkg_of_opam opam in
@@ -679,6 +701,14 @@ let generate_opam_pages state =
 
         Printf.bprintf b "%s\n"
           (modules_to_html opam.opam_mdls);
+
+        if sources then begin 
+          Printf.bprintf b "\n{1:sources Package sources}\n";
+          
+          let opam_sources = htmlize_sources_of_opam opam in
+          Printf.bprintf b {|{%%html:<a href="../../../%s/index.html">Link to the sources</a>%%}|}
+            opam_sources
+        end;
 
         Printf.bprintf b "\n{1:files Package files}\n";
         Printf.bprintf b {|{%%html:<pre>|};
@@ -839,7 +869,7 @@ let generate_meta_pages state =
 
   ()
 
-let generate ~state ~continue_on_error =
+let generate ~state ~continue_on_error ~sources =
 
   (* Iter on modules first *)
 
@@ -875,8 +905,21 @@ let generate ~state ~continue_on_error =
       )
   end;
 
+  if sources then begin
+    EzFile.make_dir ~p:true sources_dir;
+    StringMap.iter (fun _ opam ->
+      let opam_sources = sources_of_opam opam 
+      and opam_htmlize_sources = htmlize_sources_of_opam opam in
+      if not (Sys.file_exists opam_htmlize_sources) then begin
+        get_opam_sources ~continue_on_error opam;
+        Htmlize.Main.htmlize_dir Globals.htmlize_sources_dir opam_sources;
+        EzFile.remove_dir ~all:true opam_sources
+      end
+    ) state.opam_packages;
+    EzFile.remove_dir ~all:true sources_dir
+  end;
 
-  generate_opam_pages state;
+  generate_opam_pages ~sources state;
   generate_library_pages state;
   generate_meta_pages state;
   generate_module_entries state;

--- a/src/digodoc_lib/odoc.ml
+++ b/src/digodoc_lib/odoc.ml
@@ -912,7 +912,10 @@ let generate ~state ~continue_on_error ~sources =
       and opam_htmlize_sources = htmlize_sources_of_opam opam in
       if not (Sys.file_exists opam_htmlize_sources) then begin
         get_opam_sources ~continue_on_error opam;
-        Htmlize.Main.htmlize_dir Globals.htmlize_sources_dir opam_sources;
+        if not (Sys.file_exists Globals.htmlize_sources_dir) then 
+          Htmlize.Main.htmlize Globals.htmlize_sources_dir [opam_sources]
+        else
+          Htmlize.Main.htmlize_dir Globals.htmlize_sources_dir opam_sources;
         EzFile.remove_dir ~all:true opam_sources
       end
     ) state.opam_packages;

--- a/src/htmlize/main.ml
+++ b/src/htmlize/main.ml
@@ -129,7 +129,7 @@ let htmlize_file destdir srcdir path file =
   in
   generate_page ~brace destdir
 
-let dir_content srcdir files =
+let dir_content srcdir files path =
   let b = Buffer.create 1000 in
   Printf.bprintf b {|<div class="files-div"><table class="files-table">
  <tbody class="file">
@@ -138,8 +138,14 @@ let dir_content srcdir files =
   Printf.bprintf b {|  <tr class="file">
 |};
   Printf.bprintf b {|   <td class="file-icon">%s</td>|} Files.svg_directory;
-  Printf.bprintf b {|   <td class="file-name"><a href='../index.html'>&lt;PARENT DIRECTORY&gt;</a></td>
-|};
+  let parent_directory =
+    match path with
+    | [] -> assert false
+    | [_dir] -> "."
+    | _ -> ".."
+  in
+  Printf.bprintf b {|   <td class="file-name"><a href='%s/index.html'>&lt;PARENT DIRECTORY&gt;</a></td>
+|} parent_directory;
   Printf.bprintf b {|   <td class="file-kind">Upper Directory</td>
 |};
   Printf.bprintf b {|  </tr>
@@ -197,7 +203,7 @@ let rec htmlize_dir destdir srcdir path basename =
   Array.sort compare files;
 
   let brace () var = match var with
-    | "content" -> dir_content srcdir files
+    | "content" -> dir_content srcdir files path
     | "content-info" -> dir_info files
     | "title" -> String.concat "/" path
     | "title-info" -> title_info path


### PR DESCRIPTION
- Use different path for meta-files from folder _metas/_. This resolves lack of meta-file in the documentation of **ocaml-base-comiler**.
- Get source code for every opam package and add the link to the sources in package documentation.
- Cache for  _htmlized_ sources.
- Adding new option `--no-sources` that generate documentation without source's context
- Fixing link to the parent directory