### PR TITLE
Fixing typos

### DIFF
--- a/html/_odoc-theme/manual.css
+++ b/html/_odoc-theme/manual.css
@@ -43,7 +43,7 @@ table { border-collapse: collapse; border-spacing: 0; }
    classification is sometimes a bit lacking. */
 
 /* Geometry.
-   See also media adjustements at the end of the stylesheet. */
+   See also media adjustments at the end of the stylesheet. */
 
 body { background-color: var(--color-bg);
        color: var(--color-fg);
@@ -341,7 +341,7 @@ h1#sec1 ~ ul > li > ul > li { margin-top: var(--size-half-line); }
   { position: static; width: 100%;
     margin: 0; margin-top: var(--size-line); }
 
-  /* odig.light with slight adjustements */
+  /* odig.light with slight adjustments */
   :root
   { --color-bg: white;
     --color-bg-highlight: #CAD7EF;

--- a/html/_odoc-theme/odoc.css
+++ b/html/_odoc-theme/odoc.css
@@ -43,7 +43,7 @@ table { border-collapse: collapse; border-spacing: 0; width: inherit; height: in
    the desired geometry on responses.
    https://github.com/ocaml/odoc/issues/327
 
-   See also media adjustements at the end of the stylesheet. */
+   See also media adjustments at the end of the stylesheet. */
 
 body { 
       min-width: 800px;
@@ -289,7 +289,7 @@ h1 nav { display: inline-block;
  .toc { position: static; width: 100%;
         margin: 0; margin-top: var(--size-line); }
 
- /* odig.light with slight adjustements */
+ /* odig.light with slight adjustments */
  :root
  { --color-bg: white;
    --color-bg-highlight: #CAD7EF;

--- a/src/digodoc_lib/html.ml
+++ b/src/digodoc_lib/html.ml
@@ -30,7 +30,7 @@ let generate_page ~filename ~title f =
   let root = if s = "" then s else s ^ "/" in
 
 
-  (* removed 'async' from the script line because unregnized by ez_ml parser *)
+  (* removed 'async' from the script line because unrecognized by ez_ml parser *)
   let bb = Buffer.create 10000 in
   Printf.bprintf bb {|<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">

--- a/src/digodoc_lib/main.ml
+++ b/src/digodoc_lib/main.ml
@@ -182,7 +182,7 @@ let main () =
                                       opam_switch_prefix //
                                       ( Module.file m "ml") |]
           | list ->
-              Printf.printf "Found %d occurences of %S:\n%!"
+              Printf.printf "Found %d occurrences of %S:\n%!"
                 ( List.length list) mdl;
               List.iter (fun m ->
                   Printf.printf "* %s::%s\n%!"

--- a/src/digodoc_lib/type.ml
+++ b/src/digodoc_lib/type.ml
@@ -109,7 +109,7 @@ and ocaml_mdl = {
   mutable mdl_exts : StringSet.t ;
   mutable mdl_libs : ocaml_lib StringMap.t ; (* OPAM::NAME -> ocaml_lib *)
 
-  (* meta_packages where this module appears EXPLICITELY *)
+  (* meta_packages where this module appears EXPLICITLY *)
   mutable mdl_metas : meta_package StringMap.t; (* NAME -> meta_package *)
 
   mutable mdl_intf : comp_unit option ;

--- a/src/ez_html/dtd.mli
+++ b/src/ez_html/dtd.mli
@@ -39,7 +39,7 @@
 
 	While parsing Xml, PCDATA is always parsed and
 	the Xml entities &amp; &gt; &lt; &apos; &quot; are replaced by their
-	corresponding ASCII characters. For Xml attributes, theses can be
+	corresponding ASCII characters. For Xml attributes, these can be
 	put between either double or simple quotes, and the backslash character
 	can be used to escape inner quotes. There is no support for CDATA Xml
 	nodes or PCDATA attributes declarations in DTD, and no support for
@@ -53,7 +53,7 @@ type checked
 (** {6 The DTD Functions} *)
 
 (** Parse the named file into a Dtd data structure. Raise
-	{!Xml_types.File_not_found} if an error occured while opening the file.
+	{!Xml_types.File_not_found} if an error occurred while opening the file.
 	Raise {!Dtd.Parse_error} if parsing failed. *)
 val parse_file : string -> dtd
 
@@ -86,13 +86,13 @@ val to_string : dtd_item -> string
 
 (** {6 The DTD Exceptions} *)
 
-(** There is three types of DTD excecptions : {ul
-	{li {!Dtd.Parse_error} is raised when an error occured while
+(** There is three types of DTD exceptions : {ul
+	{li {!Dtd.Parse_error} is raised when an error occurred while
 	parsing a DTD document into a DTD data structure.}
-	{li {!Dtd.Check_error} is raised when an error occured while
+	{li {!Dtd.Check_error} is raised when an error occurred while
 	checking a DTD data structure for completeness, or when the
 	prove entry point is not found when calling {!Dtd.prove}.}
-	{li {!Dtd.Prove_error} is raised when an error occured while
+	{li {!Dtd.Prove_error} is raised when an error occurred while
 	proving an Xml document.}
 	}
 

--- a/src/ez_html/xml.mli
+++ b/src/ez_html/xml.mli
@@ -38,10 +38,10 @@ open Xml_types
 (** {6 Xml Parsing} *)
 
 (** For easily parsing an Xml data source into an xml data structure,
-	you can use theses functions. But if you want advanced parsing usage,
+	you can use these functions. But if you want advanced parsing usage,
 	please look at the {!XmlParser} module.
 	All the parsing functions can raise some exceptions, see the
-	{{:#exc}Exceptions} section for more informations. *)
+	{{:#exc}Exceptions} section for more information. *)
 
 (** Parse the named file into an Xml data structure. *)
 val parse_file : ?check:bool -> string -> xml
@@ -58,17 +58,17 @@ val parse_string : string -> xml
 
 (** Several exceptions can be raised when parsing an Xml document : {ul
 	{li {!Xml.Error} is raised when an xml parsing error occurs. the
-		{!Xml.error_msg} tells you which error occured during parsing
-		and the {!Xml.error_pos} can be used to retreive the document
-		location where the error occured at.}
-	{li {!Xml.File_not_found} is raised when and error occured while
+		{!Xml.error_msg} tells you which error occurred during parsing
+		and the {!Xml.error_pos} can be used to retrieve the document
+		location where the error occurred at.}
+	{li {!Xml.File_not_found} is raised when and error occurred while
 		opening a file with the {!Xml.parse_file} function or when a
 		DTD file declared by the Xml document is not found {i (see the
-		{!XmlParser} module for more informations on how to handle the
+		{!XmlParser} module for more information on how to handle the
 		DTD file loading)}.}
 	}
 	If the Xml document is containing a DTD, then some other exceptions
-	can be raised, see the module {!Dtd} for more informations.
+	can be raised, see the module {!Dtd} for more information.
  *)
 
 type error = error_msg * error_pos
@@ -83,13 +83,13 @@ val error : error -> string
 (** Get the Xml error message as a string. *)
 val error_msg : error_msg -> string
 
-(** Get the line the error occured at. *)
+(** Get the line the error occurred at. *)
 val line : error_pos -> int
 
-(** Get the relative character range (in current line) the error occured at.*)
+(** Get the relative character range (in current line) the error occurred at.*)
 val range : error_pos -> int * int
 
-(** Get the absolute character range the error occured at. *)
+(** Get the absolute character range the error occurred at. *)
 val abs_range : error_pos -> int * int
 
 (** {6 Xml Functions} *)
@@ -142,7 +142,7 @@ val fold : ('a -> xml -> 'a) -> 'a -> xml -> 'a
 (** {6 Xml Printing} *)
 
 (** Print the xml data structure into a compact xml string (without
- any user-readable formating ). *)
+ any user-readable formatting ). *)
 val to_string : xml -> string
 
 (** Print the xml data structure into an user-readable string with

--- a/src/ez_html/xmlParser.mli
+++ b/src/ez_html/xmlParser.mli
@@ -50,7 +50,7 @@ val prove : t -> bool -> unit
 (** When parsing an Xml document from a file using the {!Xml.parse_file}
  function, the DTD file if declared by the Xml document has to be in the
  same directory as the xml file. When using other parsing functions,
- such as on a string or on a channel, the parser will raise everytime
+ such as on a string or on a channel, the parser will raise every time
  {!Xml.File_not_found} if a DTD file is needed and prove enabled. To enable
  the DTD loading of the file, the user have to configure the Xml parser
  with a [resolve] function which is taking as argument the DTD filename and
@@ -70,9 +70,9 @@ val check_eof : t -> bool -> unit
  of xml document source to parse its contents into an Xml data structure. *)
 val parse :  t -> source -> Xml_types.xml
 
-(** When several PCData elements are separed by a \n (or \r\n), you can
+(** When several PCData elements are separated by a \n (or \r\n), you can
  either split the PCData in two distincts PCData or merge them with \n
- as seperator into one PCData. The default behavior is to concat the
+ as separator into one PCData. The default behavior is to concat the
  PCData, but this can be changed for a given parser with this flag. *)
 val concat_pcdata : t -> bool -> unit
 


### PR DESCRIPTION
Typos found with https://github.com/codespell-project/codespell